### PR TITLE
[Create]  s3를 이용한 이미지 업로드 기능 구현

### DIFF
--- a/users/urls.py
+++ b/users/urls.py
@@ -1,7 +1,8 @@
 from django.urls    import path
 
-from users.views    import KakaoLoginView
+from users.views    import KakaoLoginView, ImageUploader
 
 urlpatterns = [
-    path('/signin', KakaoLoginView.as_view()) 
+    path('/signin', KakaoLoginView.as_view()),
+    path('/imageUploader', ImageUploader.as_view()),
 ]

--- a/users/views.py
+++ b/users/views.py
@@ -1,12 +1,12 @@
-import json, bcrypt, jwt
+import json, bcrypt, jwt, boto3, uuid
 
-from my_settings                import ALGORITHM, SECRET_KEY
+from my_settings                import ALGORITHM, SECRET_KEY, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_STORAGE_BUCKET_NAME, IMAGE_URL
 
 from django.http                import JsonResponse, response
 from django.views               import View
 from django.core.exceptions     import ValidationError
 from core.utils.KakaoAPI        import KakaoAPI
-from users.models               import User
+from users.models               import User, Image
 
 
 class KakaoLoginView(View):
@@ -39,3 +39,24 @@ class KakaoLoginView(View):
 
         except KeyError:
             return JsonResponse({'message' : 'KEY_ERROR'}, status = 400)
+
+class ImageUploader(View) :
+    
+    def post(self, request) :
+        try :
+            files = request.FILES.getlist('files')
+            host_id = request.GET.get('host_id')
+            s3r = boto3.resource('s3', aws_access_key_id= AWS_ACCESS_KEY_ID, aws_secret_access_key= AWS_SECRET_ACCESS_KEY)
+            key = "%s" %(host_id)
+
+            for file in files :
+                file._set_name(str(uuid.uuid4()))
+                s3r.Bucket(AWS_STORAGE_BUCKET_NAME).put_object( Key=key+'/%s'%(file), Body=file, ContentType='jpg')
+                Image.objects.create(
+                    image_url = IMAGE_URL+"%s/%s"%(host_id, file),
+                    host_id = host_id
+                )
+            return JsonResponse({"MESSGE" : "SUCCESS"}, status=200)
+
+        except Exception as e :
+            return JsonResponse({"ERROR" : e.message})


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 호스트 등록시 필요한 여러장의 사진을 등록하는 기능 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 클라이언트가 파일 업로드시 request.FILES.getlist로 파일들을 받는다. 
  - files라는 키 하나로 여러개의 사진을 리스트형식으로 받아옴

2. boto3를 사용해서 접근하고자 하는 s3에 접속한다. 
 - resource 함수를 사용해서 접근 
 - 잘못된 access_key로 접근시 error message 발생

3. 업로드 받은 파일명을 uuid형태로 받아 str로 변환하여 이름 변경

4. s3에 접속하여 bucket을 선택하고 원하고자하는 파일을 업로드 시킴
 - 없는 bucket 이름을 선택시 error message 발생 
 - s3의 put_object 메소드를 사용하여 파일업로드 

5. 파일 업로드시 생성되는 객체URL을 DB에 저장시킨다. 
 - s3에 파일 업로드에 생성되는 URL의 형식 그대로 데이터베이스 이미지 테이블에 create 시킨다.
<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- s3사용법에 대해 알 수 있었습니다. 버킷 생성, IAM 유저 생성을 해봤습니다. 현재 권한 설정을 공개로 해서 진행했습니다. 
진행 과정에서 어떤 방법으로 업로드하는지 찾는 과정에서 공식문서 만으로 이해하기 힘들었습니다. 추가적인 유튜브 검색과 구글검색으로 boto3방법을 찾게 되었고 이후에 차례차례 내 노트북에있는 파일부터 s3에 업로드해보며 view 까지 작성했습니다. 
 <br />

## :: 기타 질문 및 특이 사항
- 현재 happy path로 어떤 에러가 일어날 수 있는지에 대하여 확인 하지 않았습니다. 발생가능한 에러들이 궁금합니다. 
- access_secret_key를 갖고 있지않는 환경의 서버라면 이용할수 없습니다. 이 것 또한 해결할 수 있는지 궁금합니다. 
- 추가적인 권한 설정으로 제한할 수 있는 것들에 대하여 궁금합니다.  